### PR TITLE
locate code directory properly

### DIFF
--- a/mantis_xray/helpers.py
+++ b/mantis_xray/helpers.py
@@ -2,6 +2,5 @@ def resource_path(relative_path):
     import os, sys
 
     """ Get absolute path to resource, works for dev and for PyInstaller """
-    #base_path = getattr(sys, '_MEIPASS', os.getcwd())
-    base_path = os.path.dirname(__file__)
+    base_path = getattr(sys, '_MEIPASS', os.path.dirname(__file__))
     return os.path.join(base_path, relative_path)


### PR DESCRIPTION
fixes #2 (which was already fixed) and now will work for both normal code and compiled executables.