### PR TITLE
Change the way to import colorbar due to matplotlib API change

### DIFF
--- a/mantis_xray/mantis.py
+++ b/mantis_xray/mantis.py
@@ -25,7 +25,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 #from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
-from mpl_toolkits.axes_grid1.colorbar import colorbar
+import matplotlib.colorbar as colorbar
 #from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import data_struct


### PR DESCRIPTION
Just a small change to allow importing colorbar correctly in the latest matplotlib, see [here](https://matplotlib.org/stable/api/api_changes.html#modules).