### PR TITLE
Increase energy precision to 6 decimal places and csv export not as a single comma-separated string

### DIFF
--- a/mantis_xray/data_stack.py
+++ b/mantis_xray/data_stack.py
@@ -709,7 +709,7 @@ class data:
                 return
             else:
                 for ie in range(self.n_ev):
-                    writer.writerow(['{0:06.2f}, {1:012g}'.format(evdata[ie], data[ie])])
+                    writer.writerow([f'{evdata[ie]:06.2f}', f'{data[ie]:012g}'])
                 return
 
     # ----------------------------------------------------------------------

--- a/mantis_xray/data_stack.py
+++ b/mantis_xray/data_stack.py
@@ -656,7 +656,7 @@ class data:
         print('* Address: ', file=f)
         print('*--------------------------------------------------------------', file=f)
         for ie in range(self.n_ev):
-            print('\t {0:06.2f}, {1:06f}'.format(evdata[ie], data[ie]), file=f)
+            print('\t {0:06.6f}, {1:06f}'.format(evdata[ie], data[ie]), file=f)
 
         f.close()
 
@@ -709,7 +709,7 @@ class data:
                 return
             else:
                 for ie in range(self.n_ev):
-                    writer.writerow([f'{evdata[ie]:06.2f}', f'{data[ie]:012g}'])
+                    writer.writerow([f'{evdata[ie]:06.6f}', f'{data[ie]:012g}'])
                 return
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
This PR increase the energy precision to 6 decimal places when data is exported as csv and txt. The unit of energy is often keV, and having 2 decimal places for it is not enough for high-resolution scan.

It also fixes the issue of saving energy and its intensity as a single comma-separated string. For csv data, it makes sense to save energy in one cell and its intensity in another cell, instead of energy and its intensity separated by comma in a single cell:
`|      12.34567 |        9745.24422|`  instead of `|    0012.34567,09745.24422 |                |`.