### PR TITLE
Use scipy.integrate.trapezoid

### DIFF
--- a/mantis_xray/nnma.py
+++ b/mantis_xray/nnma.py
@@ -1,6 +1,10 @@
 import numpy as np
 import scipy as sp
-from scipy.integrate import trapz
+try:
+    from scipy.integrate import trapezoid as trapz
+except ImportError:
+    # Fallback for scipy < 1.6
+    from scipy.integrate import trapz
 import sys, time
 
 from . import analyze


### PR DESCRIPTION
Use `scipy.integrate.trapezoid` unless scipy < 1.6, then use deprecated `scipy.integrate.trapz` .

Otherwise mantis GUI fails to launch with modern versions of scipy.